### PR TITLE
support macros to define which graphics lib to use for rendering

### DIFF
--- a/Wildebeast/src/wb/application/application.h
+++ b/Wildebeast/src/wb/application/application.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#if !defined(WB_VULKAN) && !defined(WB_DXX12) && !defined(WB_OGL)
+#define WB_VULKAN
+#endif
+
 #include "wb/core/core.h"
 #include "wb/core/platform.h"
 #include "wb/application/window.h"
@@ -7,18 +11,19 @@
 #include "wb/graphics/device_context.h"
 #include "wb/math/math.h"
 
+#ifdef WB_OGL
 // ogl
-//#include <GL/glew.h>
-
+#include <GL/glew.h>
+#elif defined(WB_DX12)
 // d3d12
-//#include <d3dx12.h>
-//#include <dxgi1_5.h>
-
+#include <d3dx12.h>
+#include <dxgi1_5.h>
+#elif defined(WB_VULKAN)
 // vulkan
 #define VK_USE_PLATFORM_WIN32_KHR
 #include <vulkan/vulkan.h>
 #include <vulkan/vk_sdk_platform.h>
-
+#endif
 namespace wb {
 	struct Vertex {
 		fvec3 pos;
@@ -49,20 +54,29 @@ namespace wb {
 			Window* window;
 			DeviceContext* graphicsContext;
 
-			// NOTE(Chris): TEMP for ogl triangle demo
-			u32 shader_programme;
-			i32 mvp_loc;
+			fmat4 ndc = {
+				1.0f, 0.0f, 0.0f, 0.0f,
+				0.0f, 1.0f, 0.0f, 0.0f,
+				0.0f, 0.0f, 1.0f, 0.0f,
+				0.0f, 0.0f, 0.0f, 1.0f
+			};
+
 			fmat4 mvp = {
 				1.0f, 0.0f, 0.0f, 0.0f,
 				0.0f, 1.0f, 0.0f, 0.0f,
 				0.0f, 0.0f, 1.0f, 0.0f,
 				0.0f, 0.0f, 0.0f, 1.0f
 			};
-			u32 vao;
 			i64 t = 0;
+#ifdef WB_OGL
+			// NOTE(Chris): TEMP for ogl triangle demo
+			u32 shader_programme;
+			i32 mvp_loc;
 
-			// NOTE(Chris): TEMP for d3d12 triangle demo
-			/*IDXGIFactory5* factory;
+			u32 vao;
+
+#elif defined(WB_DX12)
+			IDXGIFactory5* factory;
 			IDXGIAdapter1* adapter;
 			ID3D12Debug* debugController;
 			ID3D12Device* device;
@@ -84,9 +98,9 @@ namespace wb {
 			ID3D12PipelineState* pipelineState;
 
 			ID3D12Resource* vertexBuffer;
-			D3D12_VERTEX_BUFFER_VIEW vertexBufferView;*/
+			D3D12_VERTEX_BUFFER_VIEW vertexBufferView;
 
-			// NOTE(Chris): TEMP for vulkan triangle demo
+#elif defined(WB_VULKAN)
 			VkInstance instance;
 			VkDebugUtilsMessengerEXT debugMessenger;
 			VkPhysicalDevice physicalDevice;
@@ -115,6 +129,7 @@ namespace wb {
 			std::vector<VkDeviceMemory> uniformBuffersMemory;
 			VkDescriptorPool descriptorPool;
 			std::vector<VkDescriptorSet> descriptorSets;
+#endif
 	};
 }
 

--- a/Wildebeast/src/wb/application/d3d12_application.cpp
+++ b/Wildebeast/src/wb/application/d3d12_application.cpp
@@ -1,6 +1,7 @@
 #include "wbpch.h"
-/*
+
 #include "wb/application/application.h"
+#ifdef WB_DX12
 #include "wb/events/event_router.h"
 
 #include <D3Dcompiler.h>
@@ -97,12 +98,12 @@ namespace wb {
         ID3DBlob* vertexShader;
         ID3DBlob* pixelShader;
 
-        HRESULT hr = D3DCompileFromFile(L"C:\\Users\\ChrisPrijic\\Documents\\work\\personal\\wildebeast\\assets\\vertex.hlsl", nullptr, nullptr, "VSMain", "vs_5_0", 0, 0, &vertexShader, &error);
+        HRESULT hr = D3DCompileFromFile(L"C:\\Users\\chris\\Documents\\personal\\projects\\project_wildebeast\\assets\\vertex.hlsl", nullptr, nullptr, "VSMain", "vs_5_0", 0, 0, &vertexShader, &error);
         if (FAILED(hr)) {
             OutputDebugStringA((char*) error->GetBufferPointer());
         }
 
-        hr = D3DCompileFromFile(L"C:\\Users\\ChrisPrijic\\Documents\\work\\personal\\wildebeast\\assets\\pixel.hlsl", nullptr, nullptr, "PSMain", "ps_5_0", 0, 0, &pixelShader, &error);
+        hr = D3DCompileFromFile(L"C:\\Users\\chris\\Documents\\personal\\projects\\project_wildebeast\\assets\\pixel.hlsl", nullptr, nullptr, "PSMain", "ps_5_0", 0, 0, &pixelShader, &error);
         if (FAILED(hr)) {
             OutputDebugStringA((char*) error->GetBufferPointer());
         }
@@ -202,8 +203,8 @@ namespace wb {
 			t++;
 			platform->OnUpdate();
 
-            mvp.m14 = cos(t / 1000.0);
-            mvp.m24 = sin(t / 1000.0);
+            mvp.m41 = cos(t / 1000.0);
+            mvp.m42 = sin(t / 1000.0);
 
             const u64 cFence = fenceValue;
             cmdQueue->Signal(fence, cFence);
@@ -242,7 +243,7 @@ namespace wb {
 
             cmdList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
             cmdList->IASetVertexBuffers(0, 1, &vertexBufferView);
-            CB cb = CB{ mvp };
+            CB cb = CB{ mvp * ndc };
             cmdList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
             cmdList->SetGraphicsRoot32BitConstants(0, sizeof(fmat4) / 4, &cb, 0);
             cmdList->DrawInstanced(3, 1, 0, 0);
@@ -268,4 +269,5 @@ namespace wb {
             frameIndex = swapChain->GetCurrentBackBufferIndex();
         }
     }
-}*/
+}
+#endif

--- a/Wildebeast/src/wb/application/ogl_application.cpp
+++ b/Wildebeast/src/wb/application/ogl_application.cpp
@@ -1,6 +1,7 @@
 #include "wbpch.h"
-/*
+
 #include "wb/application/application.h"
+#ifdef WB_OGL
 #include "wb/events/event_router.h"
 
 #include <GL/glew.h>
@@ -127,7 +128,7 @@ namespace wb {
 
 			//--------------------------------------------
 			glUseProgram(shader_programme);
-			glUniformMatrix4fv(mvp_loc, 1, GL_FALSE, glPtr(mvp));
+			glUniformMatrix4fv(mvp_loc, 1, GL_FALSE, glPtr(mvp * ndc));
 			glBindVertexArray(vao);
 			// draw points 0-3 from the currently bound VAO with current in-use shader
 			glDrawArrays(GL_TRIANGLES, 0, 3);
@@ -137,4 +138,4 @@ namespace wb {
         }
     }
 }
-*/
+#endif

--- a/Wildebeast/src/wb/application/vulkan_application.cpp
+++ b/Wildebeast/src/wb/application/vulkan_application.cpp
@@ -1,6 +1,7 @@
 #include "wbpch.h"
 
 #include "wb/application/application.h"
+#ifdef WB_VULKAN
 #include "wb/events/event_router.h"
 
 #include <fstream>
@@ -45,6 +46,8 @@ namespace wb {
     }
 
     Application::Application() {
+        // RHC -> LHC
+        ndc.m22 = -1.0f;
         platform = Platform::Create();
         platform->SetEventCallback(std::bind(&Application::onEvent, this, std::placeholders::_1));
         platform->Init();
@@ -236,9 +239,9 @@ namespace wb {
         }
 
         const std::vector<Vertex> vertices = {
-            {{0.0f, -0.5f, 0.0f}, {1.0f, 0.0f, 0.0f}},
-            {{0.5f, 0.5f, 0.0f}, {0.0f, 1.0f, 0.0f}},
-            {{-0.5f, 0.5f, 0.0f}, {0.0f, 0.0f, 1.0f}}
+            {{  0.00f,  0.25f,  0.0f }, { 1.0f, 0.0f, 0.0f}},
+            {{  0.25f, -0.25f,  0.0f }, { 0.0f, 1.0f, 0.0f }},
+            {{ -0.25f, -0.25f,  0.0f }, { 0.0f, 0.0f, 1.0f }}
         };
 
         VkBufferCreateInfo bufferInfo{};
@@ -625,12 +628,12 @@ namespace wb {
             t++;
             platform->OnUpdate();
 
-            mvp.m14 = cosf(-t / 1000.0f);
-            mvp.m24 = sinf(-t / 1000.0f);
+            mvp.m41 = cosf(t / 1000.0f);
+            mvp.m42 = sinf(t / 1000.0f);
 
             vkAcquireNextImageKHR(device, swapChain, UINT64_MAX, imageAvailableSemaphore, VK_NULL_HANDLE, &frameIndex);
 
-            UBO ubo = { mvp };
+            UBO ubo = { mvp * ndc };
 
             void* data;
             vkMapMemory(device, uniformBuffersMemory[frameIndex], 0, sizeof(ubo), 0, &data);
@@ -701,3 +704,4 @@ namespace wb {
         }
     }
 }
+#endif

--- a/Wildebeast/src/wb/math/matrix.h
+++ b/Wildebeast/src/wb/math/matrix.h
@@ -2,9 +2,6 @@
 
 #include "wb/core/types.h"
 
-// for vulkan
-#define COLUMN_MAJOR
-
 namespace wb {
 #if !defined(ROW_MAJOR) && !defined(COLUMN_MAJOR)
 #define ROW_MAJOR

--- a/assets/vertex.hlsl
+++ b/assets/vertex.hlsl
@@ -1,5 +1,3 @@
-#pragma pack_matrix( row_major )
-
 cbuffer ConstantBuffer : register(b0) {
     float4x4 MVP;
 };


### PR DESCRIPTION
figured out nuances:
- they're all column-major
- Vulkan uses Right-handedness for NDC while all else uses left-handed -- use -1 on m22 to fix the NDC.